### PR TITLE
fix: format date range for Google Ads reports

### DIFF
--- a/mcc_email_alert_script.js
+++ b/mcc_email_alert_script.js
@@ -34,9 +34,11 @@ function main() {
 }
 
 function getStats(startDate, endDate) {
+  var formattedStart = startDate.replace(/-/g, '');
+  var formattedEnd = endDate.replace(/-/g, '');
   var query = 'SELECT Impressions, Clicks, Cost, Conversions, ConversionValue, AllConversions, AllConversionValue ' +
               'FROM ACCOUNT_PERFORMANCE_REPORT ' +
-              'DURING ' + startDate + ',' + endDate;
+              'DURING ' + formattedStart + ',' + formattedEnd;
   var report = AdsApp.report(query);
   var rowIter = report.rows();
   if (!rowIter.hasNext()) {


### PR DESCRIPTION
## Summary
- ensure report date range uses YYYYMMDD format by stripping dashes

## Testing
- `node --check mcc_email_alert_script.js`

------
https://chatgpt.com/codex/tasks/task_e_68b1561376b88323ae3b33cf7195158b